### PR TITLE
Fix the type signature on the `debugOperator`

### DIFF
--- a/projects/ngx-fancy-logger/src/lib/ngx-fancy-logger.service.ts
+++ b/projects/ngx-fancy-logger/src/lib/ngx-fancy-logger.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Optional } from '@angular/core';
 import { tap } from 'rxjs/operators';
+import { MonoTypeOperatorFunction } from 'rxjs';
 export enum LogLevel {
   INFO,
   DEBUG,
@@ -139,7 +140,7 @@ export class NgxFancyLoggerService implements AbstractNgxFancyLoggerService {
   }
 
   /** RxJS Debug Operator to generate Log */
-  debugOperator = (message?: string, logLevel = LogLevel.DEBUG) => tap(data => {
+  debugOperator = <T>(message?: string, logLevel = LogLevel.DEBUG): MonoTypeOperatorFunction<T> => tap(data => {
     this.log(logLevel, message || '', data);
   })
 


### PR DESCRIPTION
This allows type information to be carried over to other operators within `.pipe(...)` when using the `debugOperator`. Without this, type information is lost in subsequent operators.

---

Hi! Thanks for this library :) I wanted to contribute this small fix, which should hopefully help when using the RxJS operator. I expect this to be a non-breaking change, but wasn't sure how best to test this. Let me know if you'd like me to test this in some way.